### PR TITLE
fix borealis on linux

### DIFF
--- a/packages/b/borealis/port/xmake.lua
+++ b/packages/b/borealis/port/xmake.lua
@@ -46,6 +46,8 @@ elseif is_plat("switch") then
     add_repositories("switch-repo https://github.com/PoloNX/switch-repo")
     add_requires("libnx")
     platform_resources_path="\"romfs:/\""
+elseif is_plat("linux") then 
+    add_requires("dbus")
 end
 
 add_requires("tinyxml2")
@@ -158,6 +160,8 @@ target("borealis")
         if is_plat("macosx") then
             add_frameworks("SystemConfiguration", "CoreWlan")
             add_files("library/lib/platforms/desktop/desktop_darwin.mm")
+        elseif is_plat("linux") then 
+            add_packages("dbus")
         end
     end
     

--- a/packages/b/borealis/xmake.lua
+++ b/packages/b/borealis/xmake.lua
@@ -37,6 +37,8 @@ package("borealis")
     if is_plat("windows") then
         add_includedirs("include/compat")
         add_syslinks("wlanapi", "iphlpapi", "ws2_32")
+    elseif is_plat("linux") the,
+        add_deps("dbus")
     end
     on_load(function (package)
         local window = package:config("window")


### PR DESCRIPTION
I added dbus as a deps for borealis on linux. Without this I have an error when building.

where is used dbus in borealis : https://github.com/xfangfang/borealis/blob/9b0a06322c300b5ac07eae97d7fc266e8261ebaf/library/include/borealis/platforms/desktop/desktop_platform.hpp#L24

Error without this pr : 

```
error: @programdir/core/main.lua:329: @programdir/actions/build/main.lua:146: @programdir/modules/async/runjobs.lua:331: @programdir/modules/private/action/build/object.lua:100: @programdir/modules/core/tools/gcc.lua:1035: In file included from library/include/borealis/platforms/glfw/glfw_platform.hpp:20,
                 from library/lib/core/platform.cpp:36:
library/include/borealis/platforms/desktop/desktop_platform.hpp:24:10: fatal error: dbus/dbus.h: No such file or directory
   24 | #include <dbus/dbus.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
```

